### PR TITLE
Fix Fruit Fusion mobile tap aiming

### DIFF
--- a/fruit-fusion.html
+++ b/fruit-fusion.html
@@ -768,6 +768,7 @@
             canvasWrapper.addEventListener('pointerdown', setupSoundsOnFirstInteraction, { once: true });
             canvasWrapper.addEventListener('mousemove', handleMouseMove);
             canvasWrapper.addEventListener('click', handleCanvasClick);
+            canvasWrapper.addEventListener('touchstart', handleTouchStart);
             canvasWrapper.addEventListener('touchmove', handleTouchMove, { passive: false });
             canvasWrapper.addEventListener('touchend', handleTouchEnd);
             
@@ -920,8 +921,18 @@
         }
 
         function handleCanvasClick() {
-            if (currentAimerMatterBody && aimingFruitData && canDrop && !isGameOver && !isGamePaused) { 
+            if (currentAimerMatterBody && aimingFruitData && canDrop && !isGameOver && !isGamePaused) {
                 dropFruit();
+            }
+        }
+
+        function handleTouchStart(event) {
+            if (!currentAimerMatterBody || isGameOver || !aimingFruitData || isGamePaused || !canvasWrapper) return;
+            if (event.touches.length > 0) {
+                const touch = event.touches[0];
+                const rect = canvasWrapper.getBoundingClientRect();
+                const touchX = touch.clientX - rect.left;
+                positionAimingFruitPreview(touchX);
             }
         }
         


### PR DESCRIPTION
## Summary
- ensure that taps position the aiming fruit correctly
- update event listeners for new touch start handling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403a6e343c833085324c620b59b0b9