### PR TITLE
Implement centralized leaderboard

### DIFF
--- a/fruit-fusion.html
+++ b/fruit-fusion.html
@@ -6,6 +6,7 @@
     <title>Fruit Fusion Fun - Deluxe</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.min.js"></script>
+    <script src="leaderboard.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -540,7 +541,7 @@
         let isGameOver = false;
         let isGamePaused = false; 
         let dropCooldownTimeoutId = null;
-        let leaderboard = [];
+        const leaderboardManager = new Leaderboard('fruitFusion', MAX_LEADERBOARD_ENTRIES);
         let globalSoundsEnabled = true; 
         let currentDifficulty = 'normal'; 
         let normalGravityValue = 0.9;
@@ -1160,36 +1161,26 @@
         }
 
         function loadLeaderboard() {
-            const storedLeaderboard = localStorage.getItem('fruitFusionLeaderboard_v2');
-            leaderboard = storedLeaderboard ? JSON.parse(storedLeaderboard) : [];
-        }
-        function saveLeaderboard() {
-            localStorage.setItem('fruitFusionLeaderboard_v2', JSON.stringify(leaderboard));
+            return leaderboardManager.load();
         }
         function addScoreToLeaderboard(initials, newScore) {
-            leaderboard.push({ initials, score: newScore });
-            leaderboard.sort((a, b) => b.score - a.score); 
-            leaderboard = leaderboard.slice(0, MAX_LEADERBOARD_ENTRIES); 
-            saveLeaderboard();
+            leaderboardManager.add(initials, newScore);
         }
         function displayLeaderboard() {
-            loadLeaderboard();
-            leaderboardList.innerHTML = ''; 
-            if (leaderboard.length === 0) {
+            const board = leaderboardManager.load();
+            leaderboardList.innerHTML = '';
+            if (board.length === 0) {
                 leaderboardList.innerHTML = '<li>No scores yet! Be the first!</li>';
                 return;
             }
-            leaderboard.forEach((entry, index) => {
+            board.forEach((entry, index) => {
                 const li = document.createElement('li');
-                li.innerHTML = `<span class="rank">${index + 1}.</span> <span class="initials">${entry.initials}</span> <span class="score">${entry.score}</span>`;
+                li.innerHTML = `<span class="rank">${index + 1}.</span> <span class="initials">${entry.name || entry.initials}</span> <span class="score">${entry.score}</span>`;
                 leaderboardList.appendChild(li);
             });
         }
         function checkIfQualifiesForLeaderboard(currentScore) {
-            loadLeaderboard(); 
-            if (currentScore <= 0) return false; 
-            if (leaderboard.length < MAX_LEADERBOARD_ENTRIES) return true;
-            return currentScore > leaderboard[leaderboard.length - 1].score;
+            return leaderboardManager.qualifies(currentScore);
         }
 
         startGameButton.onclick = () => {

--- a/global-leaderboard.html
+++ b/global-leaderboard.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Global Leaderboard</title>
+  <style>
+    body { font-family: sans-serif; padding: 1rem; }
+    h1 { text-align: center; }
+    ol { list-style: none; padding: 0; max-width: 400px; margin: 0 auto; }
+    li { display: flex; justify-content: space-between; border-bottom: 1px solid #ccc; padding: 0.25rem 0; }
+    .rank { width: 2rem; font-weight: bold; }
+    .game { width: 35%; text-align: left; }
+    .name { flex-grow: 1; text-align: left; }
+    .score { font-weight: bold; }
+  </style>
+  <script src="leaderboard.js"></script>
+</head>
+<body>
+  <h1>Global Leaderboard</h1>
+  <ol id="board"></ol>
+  <script>
+    const list = document.getElementById('board');
+    const entries = GlobalLeaderboard.load();
+    renderLeaderboardList(list, entries, true);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
       <li><a href="duck-council.html">Duck Council</a></li>
       <li><a href="fruit-fusion.html">Fruit Fusion</a></li>
       <li><a href="memory-match.html">Memory Match</a></li>
+      <li><a href="global-leaderboard.html">Global Leaderboard</a></li>
       <!-- …add one <li> per game-folder -->
     </ul>
   </div>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,73 @@
+class Leaderboard {
+  constructor(gameKey, maxEntries = 10) {
+    this.gameKey = gameKey;
+    this.storageKey = `leaderboard_${gameKey}`;
+    this.maxEntries = maxEntries;
+  }
+  load() {
+    try {
+      const data = localStorage.getItem(this.storageKey);
+      return data ? JSON.parse(data) : [];
+    } catch (e) {
+      console.error('Failed to load leaderboard', e);
+      return [];
+    }
+  }
+  save(entries) {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(entries));
+    } catch (e) {
+      console.error('Failed to save leaderboard', e);
+    }
+  }
+  add(name, score) {
+    const board = this.load();
+    board.push({ name, score });
+    board.sort((a, b) => b.score - a.score);
+    const trimmed = board.slice(0, this.maxEntries);
+    this.save(trimmed);
+    GlobalLeaderboard.add(this.gameKey, name, score);
+    return trimmed;
+  }
+  qualifies(score) {
+    const board = this.load();
+    if (score <= 0) return false;
+    if (board.length < this.maxEntries) return true;
+    return score > board[board.length - 1].score;
+  }
+}
+
+const GlobalLeaderboard = {
+  key: 'global_leaderboard_v1',
+  maxEntries: 50,
+  load() {
+    try {
+      const data = localStorage.getItem(this.key);
+      return data ? JSON.parse(data) : [];
+    } catch (e) {
+      console.error('Failed to load global leaderboard', e);
+      return [];
+    }
+  },
+  save(entries) {
+    try {
+      localStorage.setItem(this.key, JSON.stringify(entries));
+    } catch (e) {
+      console.error('Failed to save global leaderboard', e);
+    }
+  },
+  add(game, name, score) {
+    const board = this.load();
+    board.push({ game, name, score });
+    board.sort((a, b) => b.score - a.score);
+    this.save(board.slice(0, this.maxEntries));
+  }
+};
+
+function renderLeaderboardList(element, entries, showGame = false) {
+  element.innerHTML = entries.length === 0 ? '<li>No scores yet!</li>' :
+    entries.map((e, i) => {
+      const gamePart = showGame ? `<span class="game">${e.game}</span> ` : '';
+      return `<li><span class="rank">${i + 1}.</span> ${gamePart}<span class="name">${e.name}</span> <span class="score">${e.score}</span></li>`;
+    }).join('');
+}

--- a/tetris.html
+++ b/tetris.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Tetris Deluxe</title>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <script src="leaderboard.js"></script>
     <style>
         :root {
             --body-bg: #1a1a2e;
@@ -388,14 +389,15 @@
             'Z': { shape: [[1, 1, 0], [0, 1, 1]], color: '#f00000' }
         };
         const PIECE_KEYS = Object.keys(TETROMINOES);
-        const MAX_HIGH_SCORES = 5;
+        const MAX_LEADERBOARD_ENTRIES = 5;
 
         // Game State
         let board, currentPiece, nextPiece, score, level, linesCleared, dropCounter, dropInterval, lastTime;
         let animationFrameId = null;
         let gamePaused = true;
         let gameOver = false;
-        let highScores = [];
+        const leaderboardManager = new Leaderboard('tetris', MAX_LEADERBOARD_ENTRIES);
+        let highScores = leaderboardManager.load();
 
         // Touch Controls Variables
         let touchstartX = 0, touchstartY = 0, touchendX = 0, touchendY = 0;
@@ -634,16 +636,13 @@
         }
 
         function loadHighScores() {
-            try {
-                const storedScores = localStorage.getItem('tetrisHighScoresDeluxe');
-                highScores = storedScores ? JSON.parse(storedScores) : [];
-            } catch (error) { console.error("Error loading high scores:", error); highScores = []; }
+            highScores = leaderboardManager.load();
             displayHighScores();
         }
         function saveHighScore(initials, newScore) {
-            highScores.push({ initials, score: newScore }); highScores.sort((a, b) => b.score - a.score);
-            highScores = highScores.slice(0, MAX_HIGH_SCORES);
-            localStorage.setItem('tetrisHighScoresDeluxe', JSON.stringify(highScores)); displayHighScores();
+            leaderboardManager.add(initials, newScore);
+            highScores = leaderboardManager.load();
+            displayHighScores();
         }
         function displayHighScores() {
             highScoreListElement.innerHTML = '';
@@ -655,7 +654,8 @@
             });
         }
         function checkHighScore() {
-            const isHighScore = highScores.length < MAX_HIGH_SCORES || score > highScores[highScores.length - 1].score;
+            highScores = leaderboardManager.load();
+            const isHighScore = highScores.length < MAX_LEADERBOARD_ENTRIES || score > highScores[highScores.length - 1].score;
             if (isHighScore && score > 0) {
                 initialsInput.value = ''; initialsPrompt.style.display = 'block'; initialsInput.focus();
             } else { showMessage("Game Over! Score: " + score, "Play Again", resetGame); }

--- a/whack-a-mole.html
+++ b/whack-a-mole.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.js"></script>
+    <script src="leaderboard.js"></script>
     <style>
         /* --- Base Styles --- */
         :root {
@@ -555,7 +556,9 @@
         let currentDifficulty = difficulties.medium;
         let score = 0; let timeLeft = 0; let timerId = null; let faceTimerId = null;
         let gameActive = false; let currentScreen = 'menu'; let totalXP = 0;
-        let leaderboard = []; let unlockedThemes = ['default']; let selectedTheme = 'default';
+        const leaderboardManager = new Leaderboard('whackAMole', MAX_LEADERBOARD_ENTRIES);
+        let leaderboard = leaderboardManager.load();
+        let unlockedThemes = ['default']; let selectedTheme = 'default';
         let unlockedRewards = []; let currentTitle = "";
         let audioInitialized = false; let soundEnabled = true;
         let selectedMusicTrackId = 'chillGroove'; 
@@ -1107,8 +1110,9 @@
             displayThemes();  
             saveData();
 
+            leaderboard = leaderboardManager.load();
             const lowestLeaderboardScore = leaderboard.length < MAX_LEADERBOARD_ENTRIES ? 0 : leaderboard[leaderboard.length - 1].score;
-            if (score > 0 && score >= lowestLeaderboardScore) { 
+            if (score > 0 && score >= lowestLeaderboardScore) {
                 gameOverInput.style.display = 'block'; nameInput.value = ''; nameInput.focus();
             } else {
                 gameOverInput.style.display = 'none';
@@ -1132,13 +1136,14 @@
              showScreen('menu');
         }
 
-        function addScoreToLeaderboard(name, scoreVal) { 
-            leaderboard.push({ name: name.toUpperCase(), score: scoreVal });
-            leaderboard.sort((a, b) => b.score - a.score);
-            leaderboard = leaderboard.slice(0, MAX_LEADERBOARD_ENTRIES);
-            saveData(); displayLeaderboard();
+        function addScoreToLeaderboard(name, scoreVal) {
+            leaderboardManager.add(name, scoreVal);
+            leaderboard = leaderboardManager.load();
+            saveData();
+            displayLeaderboard();
         }
         function displayLeaderboard() {
+            leaderboard = leaderboardManager.load();
             leaderboardList.innerHTML = leaderboard.length === 0 ? '<li>No scores yet!</li>' :
                 leaderboard.map((entry, index) => `<li><span>${index + 1}. ${entry.name}</span><span class="score">${entry.score}</span></li>`).join('');
         }
@@ -1264,8 +1269,8 @@
 
         function saveData() {
             try {
-                localStorage.setItem('whackGameDeluxeData_v4', JSON.stringify({ 
-                    totalXP, leaderboard, unlockedThemes, selectedTheme, unlockedRewards, currentTitle, soundEnabled, playerStats, selectedMusicTrackId
+                localStorage.setItem('whackGameDeluxeData_v4', JSON.stringify({
+                    totalXP, unlockedThemes, selectedTheme, unlockedRewards, currentTitle, soundEnabled, playerStats, selectedMusicTrackId
                 }));
             } catch (e) { console.error("Failed to save data:", e); }
         }
@@ -1273,12 +1278,13 @@
             try {
                 const data = JSON.parse(localStorage.getItem('whackGameDeluxeData_v4'));
                 if (data) {
-                    totalXP = data.totalXP || 0; leaderboard = data.leaderboard || [];
+                    totalXP = data.totalXP || 0;
                     unlockedThemes = data.unlockedThemes || ['default']; selectedTheme = data.selectedTheme || 'default';
                     unlockedRewards = data.unlockedRewards || []; currentTitle = data.currentTitle || "";
                     soundEnabled = typeof data.soundEnabled === 'boolean' ? data.soundEnabled : true;
                     playerStats = data.playerStats || { totalGamesPlayed: 0, totalWhacks: 0, totalScore: 0, difficultyPlays: { easy: 0, medium: 0, hard: 0, marathon: 0 }};
                     selectedMusicTrackId = data.selectedMusicTrackId || 'chillGroove';
+                    if (data.leaderboard) leaderboardManager.save(data.leaderboard);
                 }
                  // TEMPORARY: Grant XP for testing
                  totalXP = 2500; 
@@ -1310,7 +1316,9 @@
         interactionOverlay.addEventListener('click', initAudio, { once: true });
 
         function initializeGame() {
-            loadData(); createGrid(); setupAnimatedTitle();
+            loadData();
+            leaderboard = leaderboardManager.load();
+            createGrid(); setupAnimatedTitle();
             if (themes[selectedTheme] && themes[selectedTheme].className) document.body.classList.add(themes[selectedTheme].className);
             updateMenuUI(); 
             displayRewards(); 


### PR DESCRIPTION
## Summary
- add a `leaderboard.js` helper with local/global leaderboard support
- add a global leaderboard page and link from the main menu
- refactor Fruit Fusion, Whack‑a‑Mole and Tetris to use the new API

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840399ce15c8330a8114e2d24202a9f