### PR TITLE
Improve leaderboard and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# test-gemini-game
+# Gemini Game Experiments
 
+This repo collects a handful of small web games created with help from the
+Gemini 2.5 Pro (preview) model. The purpose is to explore how quickly AI can
+bootstrap functional game prototypes.
 
+Each game was initially produced with Gemini and later refined with OpenAI's
+Codex-1 Research Preview. They remain fairly rough around the edges, but serve
+as a useful snapshot of modern AI coding ability.
 
+## Running the games
 
-This repo is a collection of games Gemini 2.5 Pro (preview) I/O 05-12-25 Edition and I have collaborated on after a couple of hours each.
-The goal of this repo is to identify the current abilities of SOTA AI in low-friction creation of functional coding projects, like simple web games.
-Each game was initially coded entirely with Gemini through my prompting and suggestions.
+Open `index.html` in a browser to access the menu of all games. Some browsers
+restrict `localStorage` when opening files directly from disk, so launching a
+simple local web server (for example `python3 -m http.server`) is recommended.
 
-The games are likely full of bugs and are more proof-of-concept as to the current status of AI than functioning games or a demonstration of my personal skill.
-
-In addition to using Gemini to help create the games and scripts, I now use OpenAI's Codex-1 Research Preview to identify and fix bugs throughout the repo.
+The leaderboard system uses `localStorage` to persist scores locally and across
+games. A global leaderboard page aggregates results from individual games.

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -60,14 +60,25 @@ const GlobalLeaderboard = {
     const board = this.load();
     board.push({ game, name, score });
     board.sort((a, b) => b.score - a.score);
-    this.save(board.slice(0, this.maxEntries));
+    const trimmed = board.slice(0, this.maxEntries);
+    this.save(trimmed);
+    return trimmed;
   }
 };
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
 
 function renderLeaderboardList(element, entries, showGame = false) {
   element.innerHTML = entries.length === 0 ? '<li>No scores yet!</li>' :
     entries.map((e, i) => {
-      const gamePart = showGame ? `<span class="game">${e.game}</span> ` : '';
-      return `<li><span class="rank">${i + 1}.</span> ${gamePart}<span class="name">${e.name}</span> <span class="score">${e.score}</span></li>`;
+      const gamePart = showGame ? `<span class="game">${escapeHtml(e.game)}</span> ` : '';
+      return `<li><span class="rank">${i + 1}.</span> ${gamePart}<span class="name">${escapeHtml(e.name)}</span> <span class="score">${e.score}</span></li>`;
     }).join('');
 }

--- a/tetris.html
+++ b/tetris.html
@@ -649,7 +649,7 @@
             if (highScores.length === 0) { highScoreListElement.innerHTML = '<li>No scores yet!</li>'; return; }
             highScores.forEach((entry, index) => {
                 const li = document.createElement('li');
-                li.innerHTML = `<span class="rank">${index + 1}.</span> <span class="initials">${entry.initials}</span> <span class="score">${entry.score}</span>`;
+                li.innerHTML = `<span class="rank">${index + 1}.</span> <span class="initials">${entry.name}</span> <span class="score">${entry.score}</span>`;
                 highScoreListElement.appendChild(li);
             });
         }


### PR DESCRIPTION
## Summary
- sanitize leaderboard names to prevent HTML injection
- fix Tetris leaderboard display
- expand README with usage instructions

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68403b34fc8083309f6d2fb7614cd34e