### PR TITLE
Fix Fruit Fusion difficulty setting

### DIFF
--- a/fruit-fusion.html
+++ b/fruit-fusion.html
@@ -630,6 +630,8 @@
         }
 
         function initializeGame() {
+            // Ensure the latest difficulty setting is applied before a new game starts
+            loadDifficultyPreference();
             console.log("[DEBUG] INIT: Initializing game...");
             isGameOver = false;
             isGamePaused = false;


### PR DESCRIPTION
## Summary
- load difficulty prefs whenever a new Fruit Fusion game begins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403da8628c83309083fdda52e04f78